### PR TITLE
Smoke test container build with CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     docker:
       - image: circleci/ruby:2.6.1
-      - image: quay.io/upennlibraries/franklinforms:${CIRCLE_SHA1:0:7}
+      - image: quay.io/upennlibraries/franklinforms:${CIRCLE_SHA1}
         environment:
           SECRET_KEY_BASE: x
     steps:
@@ -25,8 +25,9 @@ workflows:
           context: quay.io
           registry: quay.io
           image: upennlibraries/franklinforms
-          tag: ${CIRCLE_SHA1:0:7}
+          tag: ${CIRCLE_SHA1}
           extra_build_args: >-
+            -t quay.io/upennlibraries/franklinforms:${CIRCLE_SHA1:0:7}
             --label "edu.upenn.library.build-system=circleci"
             --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"
             --label "edu.upenn.library.circleci.build-timestamp=$(date -uIs)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,14 @@ workflows:
           registry: quay.io
           image: upennlibraries/franklinforms
           tag: circleci.${CIRCLE_SHA1}
+          extra_build_args: >-
+            --label "edu.upenn.library.build-system=circleci"
+            --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"
+            --label "edu.upenn.library.circleci.build-url=${CIRCLE_BUILD_URL}"
+            --label "edu.upenn.library.circleci.git-branch=${CIRCLE_BRANCH}"
+            --label "edu.upenn.library.circleci.git-commit=${CIRCLE_SHA1}"
+            --label "edu.upenn.library.circleci.git-repo-url=${CIRCLE_REPOSITORY_URL}"
+            --label "edu.upenn.library.circleci.workflow-id=${CIRCLE_WORKFLOW_ID}"
       - test:
           requires:
             - docker-publish/publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     docker:
       - image: circleci/ruby:2.6.1
-      - image: quay.io/upennlibraries/franklinforms:circleci.${CIRCLE_SHA1:0:7}
+      - image: quay.io/upennlibraries/franklinforms:${CIRCLE_SHA1:0:7}
         environment:
           SECRET_KEY_BASE: x
     steps:
@@ -25,7 +25,7 @@ workflows:
           context: quay.io
           registry: quay.io
           image: upennlibraries/franklinforms
-          tag: circleci.${CIRCLE_SHA1:0:7}
+          tag: ${CIRCLE_SHA1:0:7}
           extra_build_args: >-
             --label "edu.upenn.library.build-system=circleci"
             --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,11 +3,26 @@ version: 2.1
 orbs:
   docker-publish: circleci/docker-publish@0.1.6
 
+jobs:
+  test:
+    docker:
+      - image: circleci/ruby:2.6.1
+      - image: quay.io/upennlibraries/franklinforms:circleci.${CIRCLE_BUILD_NUM}
+        environment:
+          SECRET_KEY_BASE: x
+    steps:
+      - run:
+          name: Smoke Test Container
+          command: curl --retry 5 --retry-connrefused http://localhost:80
+
 workflows:
-  build_and_publish:
+  build_and_test:
     jobs:
       - docker-publish/publish:
           context: quay.io
           registry: quay.io
           image: upennlibraries/franklinforms
           tag: circleci.${CIRCLE_BUILD_NUM}
+      - test:
+          requires:
+            - docker-publish/publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     docker:
       - image: circleci/ruby:2.6.1
-      - image: quay.io/upennlibraries/franklinforms:circleci.${CIRCLE_SHA1}
+      - image: quay.io/upennlibraries/franklinforms:circleci.${CIRCLE_SHA1:0:7}
         environment:
           SECRET_KEY_BASE: x
     steps:
@@ -25,7 +25,7 @@ workflows:
           context: quay.io
           registry: quay.io
           image: upennlibraries/franklinforms
-          tag: circleci.${CIRCLE_SHA1}
+          tag: circleci.${CIRCLE_SHA1:0:7}
           extra_build_args: >-
             --label "edu.upenn.library.build-system=circleci"
             --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,13 +7,16 @@ jobs:
   test:
     docker:
       - image: circleci/ruby:2.6.1
-      - image: quay.io/upennlibraries/franklinforms:circleci.${CIRCLE_BUILD_NUM}
+      - image: quay.io/upennlibraries/franklinforms:circleci.7
         environment:
           SECRET_KEY_BASE: x
     steps:
       - run:
           name: Smoke Test Container
-          command: curl --retry 5 --retry-connrefused http://localhost:80
+          command: |
+            wget \
+              -q -t 5 --retry-connrefused -O /dev/null \
+              http://localhost:80/redir/help
 
 workflows:
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   test:
     docker:
       - image: circleci/ruby:2.6.1
-      - image: quay.io/upennlibraries/franklinforms:circleci.7
+      - image: quay.io/upennlibraries/franklinforms:circleci.${CIRCLE_SHA1}
         environment:
           SECRET_KEY_BASE: x
     steps:
@@ -25,7 +25,7 @@ workflows:
           context: quay.io
           registry: quay.io
           image: upennlibraries/franklinforms
-          tag: circleci.${CIRCLE_BUILD_NUM}
+          tag: circleci.${CIRCLE_SHA1}
       - test:
           requires:
             - docker-publish/publish

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,7 @@ workflows:
           extra_build_args: >-
             --label "edu.upenn.library.build-system=circleci"
             --label "edu.upenn.library.circleci.build-number=${CIRCLE_BUILD_NUM}"
+            --label "edu.upenn.library.circleci.build-timestamp=$(date -uIs)"
             --label "edu.upenn.library.circleci.build-url=${CIRCLE_BUILD_URL}"
             --label "edu.upenn.library.circleci.git-branch=${CIRCLE_BRANCH}"
             --label "edu.upenn.library.circleci.git-commit=${CIRCLE_SHA1}"


### PR DESCRIPTION
This performs a basic connectivity test against the built container after it's published to Quay. I've also updated our tags to use short and long Git commit hashes and labeled the images with excessive amounts of possibly useful build metadata. 🍵 