### PR TITLE
Use Gitleaks orb to check for secrets

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ workflows:
   build_and_test:
     jobs:
       - gitleaks/check_local:
-          image: quay.io/upennlibraries/gitleaks:v1.23.0
+          image: quay.io/upennlibraries/gitleaks:v1.24.0
           options: --redact --repo-config
       - docker-publish/publish:
           context: quay.io

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   docker-publish: circleci/docker-publish@0.1.6
-  gitleaks: upenn-libraries/gitleaks@dev:2e44fdc
+  gitleaks: upenn-libraries/gitleaks@0.1.0
 
 jobs:
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,9 @@ version: 2.1
 
 orbs:
   docker-publish: circleci/docker-publish@0.1.6
+  gitleaks: upenn-libraries/gitleaks@dev:2e44fdc
 
 jobs:
-  gitleaks:
-    docker:
-      - image: quay.io/upennlibraries/gitleaks:v1.23.0
-    steps:
-      - run:
-          name: Audit Repository for Secrets
-          command: |
-            git clone https://github.com/upenn-libraries/franklinforms.git /root/project
-            gitleaks --repo-path=/root/project --redact --repo-config
   test:
     docker:
       - image: circleci/ruby:2.6.1
@@ -30,7 +22,9 @@ jobs:
 workflows:
   build_and_test:
     jobs:
-      - gitleaks
+      - gitleaks/check_local:
+          image: quay.io/upennlibraries/gitleaks:v1.23.0
+          options: --redact --repo-config
       - docker-publish/publish:
           context: quay.io
           registry: quay.io


### PR DESCRIPTION
We can now use our published Gitleaks Orb to check for secrets without having to copy our common config around. :shipit: 