### PR TITLE
Clarify BBM via ILL confirmation email

### DIFF
--- a/app/mailers/form_mailer.rb
+++ b/app/mailers/form_mailer.rb
@@ -141,6 +141,8 @@ class FormMailer < ApplicationMailer
       @bbm = true
       @from = 'bkbymail@pobox.upenn.edu'
       bib['booktitle'] = bib['booktitle'][4..-1]
+    else
+      @bbm = false
     end
 
     if(bib['requesttype'].downcase == 'book')

--- a/app/mailers/form_mailer.rb
+++ b/app/mailers/form_mailer.rb
@@ -136,8 +136,10 @@ class FormMailer < ApplicationMailer
 
     end
 
-    # remove BBM prefix if present
+    # remove BBM prefix if present, also, set other overrides for pseudo-BBM confirmation
     if bib['booktitle'].starts_with?('BBM ')
+      @bbm = true
+      @from = 'bkbymail@pobox.upenn.edu'
       bib['booktitle'] = bib['booktitle'][4..-1]
     end
 

--- a/app/views/form_mailer/confirmillbook.text.erb
+++ b/app/views/form_mailer/confirmillbook.text.erb
@@ -1,4 +1,9 @@
+<% if @bbm %>
+Your Books by Mail request has been received. You will receive notification when it about to be shipped to your home address.
+<% else %>
 Your request has been sent. <%= @addldeliveryinfo %>
+<% end %>
+
 
 You requested:
 


### PR DESCRIPTION
When submitting a BBM request via the ILL form, we need to change the confirmation email to come from the BBM staff email address, and use language that makes it clear that the submission was for BBM and not ILL. Closes #35.