### PR TITLE
ILL downtime info & update resource sharing page

### DIFF
--- a/app/controllers/concerns/pre_processor.rb
+++ b/app/controllers/concerns/pre_processor.rb
@@ -34,6 +34,10 @@ module PreProcessor
       when 'resourcesharing'
         return {user: User.new(username)}
       when 'ill', 'facultyexpress'
+        # redirect to resource sharing page during ill downtime
+        # redirect_to '/forms/resourcesharing'
+        # return
+
         proxy_id = nil
         unless params['upennproxyid'].nil? || params['upennproxyid'].empty?
           proxy_id = params['upennproxyid']

--- a/app/views/form/ill.html.erb
+++ b/app/views/form/ill.html.erb
@@ -5,6 +5,13 @@
 
 <%= render 'bbm_warnings' if params[:deliverytype] == 'bbm'  %>
 
+<div class="row">
+  <div class="col alert alert-warning">
+    Faculty Express, Digital Delivery, and Books By Mail will be unavailable on Wednesday, August 26, from noon to 5pm
+    due to necessary systems maintenance. We apologize for the interruption.
+  </div>
+</div>
+
 <%= render :partial => "form/proxy" %>
 
 <%= bootstrap_form_tag layout: :horizontal, label_col: 'col-sm-6 col-md-2', control_col: 'col-sm-6 col-md-10', html: { :onsubmit => "return submit_ill()" } do |f| %>

--- a/app/views/form/resourcesharing.html.erb
+++ b/app/views/form/resourcesharing.html.erb
@@ -20,24 +20,10 @@
         <li><%= link_to "BorrowDirect+", "http://hdl.library.upenn.edu/1017/125512" %>
           <ul>
             <li><%= link_to "BorrowDirect", bd_url %></li>
-            <li><%= link_to "E-ZBorrow", ezb_url %></li>
           </ul>
         </li>
         <li><%= link_to "InterLibrary Loan / Document Delivery", "http://hdl.library.upenn.edu/1017/125512/1" %>
-          <ul>
-            <li><%= link_to "Request Article / Chapter", ill_article_url %></li>
-            <li><%= link_to "Request Book / Media", ill_book_url %></li>
-            <li><%= link_to "View Current Requests", "https://atlas.library.upenn.edu/cgi-bin/forms/webdeliver?action=status" %></li>
-          </ul>
-        </li>
-        <li><%= link_to "FacultyEXPRESS", "http://hdl.library.upenn.edu/1017/125512/4" %>
-          <ul>
-            <li><%= link_to "Request Article / Chapter", ill_article_url %></li>
-            <li><%= link_to "Request Book / Media", ill_book_url %></li>
-            <li><%= link_to "View Current Requests", "https://atlas.library.upenn.edu/cgi-bin/forms/webdeliver?action=status" %></li>
-          </ul>
-        </li>
-	<li><%= link_to "Web Delivery", "http://hdl.library.upenn.edu/1017/125512/3" %>
+        <li><%= link_to "Web Delivery", "http://hdl.library.upenn.edu/1017/125512/3" %>
           <ul>
             <li><%= link_to "ILL / Document Delivery Pickup", "https://atlas.library.upenn.edu/cgi-bin/forms/webdeliver?action=delivered" %></li>
           </ul>
@@ -46,10 +32,18 @@
     </div>
     <div class="col-sm-12 col-md-9">
       <div class="row">
+        <div class="col alert alert-warning">
+          <%# switch to danger class for extra viz during actual downtime %>
+<!--        <div class="col alert alert-danger">-->
+          Faculty Express, Digital Delivery, and Books By Mail will be unavailable on Wednesday, August 26, from noon to
+          5pm due to necessary systems maintenance. We apologize for the interruption.
+        </div>
+      </div>
+      <div class="row">
         <div class="col">
           <h1>How to Get Books Not Available at Penn Libraries</h1>
           <div>
-            <h2>Direct request services for books: BorrowDirect and E-ZBorrow</h2>
+            <h2>Direct request service for books: BorrowDirect</h2>
               <ul>
                 <li>Search multiple library collections simultaneously; place your own requests</li>
                 <li>Fast delivery in 3 - 5 days</li>
@@ -61,16 +55,10 @@
       </div>
 
       <div id="relaiswrapper" class="row">
-        <div id="borrowdirect" class="col-sm-12 col-md-6">
+        <div id="borrowdirect" class="col-sm-12 col-md-12">
           <div><%= bd_logo %></div>
           <div>Borrow books directly from Brown, Columbia, Cornell, Dartmouth, Duke, Harvard, Johns Hopkins, MIT, Princeton, Stanford, the University of Chicago, Yale, and the Center for Research Libraries.</div>
           <div><%= link_to "Connect to BorrowDirect", bd_url %></div>
-        </div>
-        
-        <div id="ezborrow" class="col-sm-12 col-md-6">
-          <div><%= ezb_logo %></div>
-          <div>Books available from over 60 academic libraries in Pennsylvania and nearby states.</div>
-          <div><%= link_to "Connect to E-ZBorrow", ezb_url %></div>
         </div>
       </div>
 
@@ -79,24 +67,20 @@
           <h2>Features and Policies</h2>
           <ul>
             <li>Searching and discovery: Keyword and advanced author, title, and subject searching, in an updated interface.</li>
-            <li>Loan period: BorrowDirect - 16 weeks with no renewals, E-ZBorrow - 12 weeks with no renewals.</li>
-            <li>Integration with your Library account: BorrowDirect and E-ZBorrow books will be charged on your account just like Penn books. Please note: late fines of $1/day will apply.</li>
-            <li>Account information: In addition to automatic email notification, you can now view and track items borrowed using "My Account" in Franklin, or through BorrowDirect and E-ZBorrow.</li>
+            <li>Loan period: BorrowDirect - 16 weeks with no renewals<!--, E-ZBorrow - 12 weeks with no renewals-->.</li>
+            <li>Integration with your Library account: BorrowDirect <!-- and E-ZBorrow --> books will be charged on your account just like Penn books. Please note: late fines of $1/day will apply.</li>
+            <li>Account information: In addition to automatic email notification, you can now view and track items borrowed using "My Account" in Franklin, or through BorrowDirect<!-- and E-ZBorrow -->.</li>
             <li>Delivery options: Books may be delivered to any Penn Library for pick-up.</li>
-            <li>Linking to Interlibrary Loan: Requests for books that cannot be supplied by BorrowDirect and E-ZBorrow may be passed directly to Interlibrary Loan.</li>
+            <li>Linking to Interlibrary Loan: Requests for books that cannot be supplied by BorrowDirect <!--and E-ZBorrow--> may be passed directly to Interlibrary Loan.</li>
           </ul>
         </div>
       </div>
         
       <div class="row">
         <div class="col">
-          <h2>Interlibrary Loan</h2>
-          <div>For books not available in either E-ZBorrow or BorrowDirect, and for all non-book materials (audio recordings, video recordings, or microtext)</div>
-          <div class="bold">Use Interlibrary Loan:
-            <a href="<%= ill_article_url %>">Article request</a>
-            |
-            <a href="<%= ill_book_url %>">Other format request</a>
-          </div>
+          <h2>Interlibrary Loan and E-ZBorrow</h2>
+          <p>Interlibrary Loan and E-ZBorrow services are currently suspended due to COVID-19. Please place requests via
+            BorrowDirect or <%= mail_to 'interlib@pobox.upenn.edu', 'contact us' %> for assistance.</p>
         </div>
       </div>
 

--- a/app/views/form/resourcesharing.html.erb
+++ b/app/views/form/resourcesharing.html.erb
@@ -67,11 +67,11 @@
           <h2>Features and Policies</h2>
           <ul>
             <li>Searching and discovery: Keyword and advanced author, title, and subject searching, in an updated interface.</li>
-            <li>Loan period: BorrowDirect - 16 weeks with no renewals<!--, E-ZBorrow - 12 weeks with no renewals-->.</li>
-            <li>Integration with your Library account: BorrowDirect <!-- and E-ZBorrow --> books will be charged on your account just like Penn books. Please note: late fines of $1/day will apply.</li>
-            <li>Account information: In addition to automatic email notification, you can now view and track items borrowed using "My Account" in Franklin, or through BorrowDirect<!-- and E-ZBorrow -->.</li>
+            <li>Loan period: BorrowDirect - 16 weeks with no renewals.</li>
+            <li>Integration with your Library account: BorrowDirect books will be charged on your account just like Penn books. Please note: late fines of $1/day will apply.</li>
+            <li>Account information: In addition to automatic email notification, you can now view and track items borrowed using "My Account" in Franklin, or through BorrowDirect.</li>
             <li>Delivery options: Books may be delivered to any Penn Library for pick-up.</li>
-            <li>Linking to Interlibrary Loan: Requests for books that cannot be supplied by BorrowDirect <!--and E-ZBorrow--> may be passed directly to Interlibrary Loan.</li>
+            <li>Linking to Interlibrary Loan: Requests for books that cannot be supplied by BorrowDirect may be passed directly to Interlibrary Loan.</li>
           </ul>
         </div>
       </div>


### PR DESCRIPTION
add warning notice about impending ILL service downtime to ILL form. update resourcesharing page to remove information about unavailable services and the ILL downtime. add provisions for disabling ILL form and redirecting to resourcesharing page during upcoming downtime.

