### PR TITLE
redirect users from /forms/ill to resource sharing page during ILL downntime

### DIFF
--- a/app/controllers/concerns/pre_processor.rb
+++ b/app/controllers/concerns/pre_processor.rb
@@ -36,8 +36,8 @@ module PreProcessor
         return {user: User.new(username)}
       when 'ill', 'facultyexpress'
         # redirect to resource sharing page during ill downtime
-        # redirect_to '/forms/resourcesharing'
-        # return
+        redirect_to '/forms/resourcesharing'
+        return
 
         proxy_id = nil
         unless params['upennproxyid'].nil? || params['upennproxyid'].empty?

--- a/app/views/form/ill.html.erb
+++ b/app/views/form/ill.html.erb
@@ -5,13 +5,6 @@
 
 <%= render 'bbm_warnings' if params[:deliverytype] == 'bbm'  %>
 
-<div class="row">
-  <div class="col alert alert-warning">
-    Faculty Express, Digital Delivery, and Books By Mail will be unavailable on Wednesday, August 26, from noon to 5pm
-    due to necessary systems maintenance. We apologize for the interruption.
-  </div>
-</div>
-
 <%= render :partial => "form/proxy" %>
 
 <%= bootstrap_form_tag layout: :horizontal, label_col: 'col-sm-6 col-md-2', control_col: 'col-sm-6 col-md-10', html: { :onsubmit => "return submit_ill()" } do |f| %>

--- a/app/views/form/resourcesharing.html.erb
+++ b/app/views/form/resourcesharing.html.erb
@@ -33,7 +33,7 @@
     <div class="col-sm-12 col-md-9">
       <div class="row">
         <div class="col alert alert-danger">
-          Faculty Express, Digital Delivery, and Books By Mail will be unavailable on Wednesday, August 26, from noon to
+          Faculty Express, Digital Delivery, and Books By Mail will be unavailable on Thursday, August 27, from noon to
           5pm due to necessary systems maintenance. We apologize for the interruption.
         </div>
       </div>

--- a/app/views/form/resourcesharing.html.erb
+++ b/app/views/form/resourcesharing.html.erb
@@ -32,9 +32,7 @@
     </div>
     <div class="col-sm-12 col-md-9">
       <div class="row">
-        <div class="col alert alert-warning">
-          <%# switch to danger class for extra viz during actual downtime %>
-<!--        <div class="col alert alert-danger">-->
+        <div class="col alert alert-danger">
           Faculty Express, Digital Delivery, and Books By Mail will be unavailable on Wednesday, August 26, from noon to
           5pm due to necessary systems maintenance. We apologize for the interruption.
         </div>

--- a/spec/features/forms_spec.rb
+++ b/spec/features/forms_spec.rb
@@ -25,7 +25,7 @@ RSpec.feature 'Form rendering and submission', type: :feature do
     }
   end
   context 'for ILL' do
-    scenario 'the form is rendered as expected using param data' do
+    xscenario 'the form is rendered as expected using param data' do
       visit form_path({ id: 'ill', requesttype: 'ScanDelivery' }.merge(book_params))
       expect(page).to have_text 'Bibliographic information for the item requested'
       expect(page).to have_field 'Journal/Book Title', with: 'Phenomenology of perception /'
@@ -45,7 +45,7 @@ RSpec.feature 'Form rendering and submission', type: :feature do
     end
   end
   context 'for FacultyEXPRESS' do
-    scenario 'the form is rendered as expected using param data' do
+    xscenario 'the form is rendered as expected using param data' do
       visit form_path({ id: 'ill', requesttype: 'book' }.merge(book_params))
       expect(page).to have_text 'Bibliographic information for the item requested'
       expect(page).to have_field 'Title', with: 'Phenomenology of perception /'


### PR DESCRIPTION
Do not deploy until `TBD`